### PR TITLE
MariaDB Module

### DIFF
--- a/fabtools/require/__init__.py
+++ b/fabtools/require/__init__.py
@@ -6,6 +6,7 @@ import fabtools.require.deb
 import fabtools.require.files
 import fabtools.require.git
 import fabtools.require.mercurial
+import fabtools.require.mariadb
 import fabtools.require.mysql
 import fabtools.require.nginx
 import fabtools.require.nodejs

--- a/fabtools/require/mariadb.py
+++ b/fabtools/require/mariadb.py
@@ -15,7 +15,9 @@ from fabtools.system import distrib_codename
 
 def server(version='10.0', password=None):
     """
-    Require a MySQL server to be installed and running.
+    Require a MariaDB server to be installed and running.  'Version' is the high level MariaDB series
+    available (See https://downloads.mariadb.com/files/MariaDB/repo).  Not all versions available for
+    all Deb systems.  Double check availability at mariadb.org.
 
     Example::
 

--- a/fabtools/require/mariadb.py
+++ b/fabtools/require/mariadb.py
@@ -1,0 +1,48 @@
+"""
+MariaDB
+=====
+
+This module provides high-level tools for installing a MariaDB server.
+Use the MySQL module to create users and databases.
+"""
+
+from fabric.api import hide, prompt, settings
+
+from fabtools.deb import is_installed, preseed_package
+from fabtools.require.deb import package, key, source
+from fabtools.require.service import started
+from fabtools.system import distrib_codename
+
+def server(version='10.0', password=None):
+    """
+    Require a MySQL server to be installed and running.
+
+    Example::
+
+        from fabtools import require
+
+        require.mariadb.server(version='10.0', password='s3cr3t')
+
+    """
+    if version:
+        pkg_name = 'mariadb-server-%s' % version
+    else:
+        pkg_name = 'mariadb-server'
+
+    if not is_installed(pkg_name):
+        key(keyid='0xcbcb082a1bb943db', keyserver='keyserver.ubuntu.com')
+        source_url = 'http://ftp.osuosl.org/pub/mariadb/repo/%s/ubuntu' % version
+        source('mariadb', source_url, distrib_codename(), 'main')
+
+        if password is None:
+            password = prompt('Please enter password for MariaDB user "root":')
+        
+        with settings(hide('running')):
+            preseed_package(pkg_name, {
+                'mysql-server/root_password': ('password', password),
+                'mysql-server/root_password_again': ('password', password),
+            })
+
+        package(pkg_name)
+
+    started('mysql')


### PR DESCRIPTION
This module installs MariaDB server.  It mimics the MySQL module except it also adds the MariaDB key and repo.  Create users/databases are not included because the MySQL module can be used.