### PR TITLE
Added --ff-only option git pull

### DIFF
--- a/fabtools/git.py
+++ b/fabtools/git.py
@@ -137,7 +137,7 @@ def fetch(path, use_sudo=False, user=None, remote=None):
             run(cmd)
 
 
-def pull(path, use_sudo=False, user=None, force=False):
+def pull(path, use_sudo=False, user=None, force=False, ff_only=False):
     """
     Fetch changes from the default remote repository and merge them.
 
@@ -156,6 +156,8 @@ def pull(path, use_sudo=False, user=None, force=False):
     :type user: str
     :param force: If ``True``, append the ``--force`` option to the command.
     :type force: bool
+    :param ff_only: If ``True``, append the ``--ff-only`` option to the command.
+    :type ff_only: bool
     """
 
     if path is None:
@@ -165,6 +167,8 @@ def pull(path, use_sudo=False, user=None, force=False):
     options = []
     if force:
         options.append('--force')
+     if ff_only:
+        options.append('--ff-only')
     options = ' '.join(options)
 
     cmd = 'git pull %s' % options


### PR DESCRIPTION
This is necessary in case of automatic deployments because avoids running into a merge conflict